### PR TITLE
Added server_url env variable. Removed input for server url, disabled…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ To create and run the docker container, first change into the `docker/` director
 # Client settings
 VITE_ENVIRONMENT=production
 VITE_USE_HTTP=True
+VITE_SERVER_URL=localhost/data
 
 # Docker Container Only Settings
 DATABASE_ROOT_PASSWORD=root_pass

--- a/apps/client/src/components/globalSettings/DatasetSelector.vue
+++ b/apps/client/src/components/globalSettings/DatasetSelector.vue
@@ -5,16 +5,13 @@ import { useGlobalSettings } from '@/stores/globalSettings';
 import { useDatasetSelectionTrrackedStore } from '@/stores/datasetSelectionTrrackedStore';
 import { useDatasetSelectionStore } from '@/stores/datasetSelectionStore';
 import { useDataPointSelection } from '@/stores/dataPointSelection';
-import { useConfigStore } from '@/stores/configStore';
 
 const globalSettings = useGlobalSettings();
 const datasetSelectionStore = useDatasetSelectionStore();
 const datasetSelectionTrrackedStore = useDatasetSelectionTrrackedStore();
 const dataPointSelection = useDataPointSelection();
 const $q = useQuasar();
-const configStore = useConfigStore();
 
-const serverInputRef = ref<any>(null);
 watch(
     () => datasetSelectionStore.fetchingTabularData,
     () => {
@@ -61,30 +58,22 @@ function openExampleDataset() {
         @click="openExampleDataset"
         >Load Example Dataset</q-btn
     >
-    <q-input
-        ref="serverInputRef"
-        v-model="datasetSelectionTrrackedStore.serverUrl"
-        filled
-        type="url"
-        :label="configStore.useHttp ? 'http://' : 'https://'"
-        :suffix="datasetSelectionTrrackedStore.entryPointFilename"
-        debounce="1000"
-        :loading="datasetSelectionStore.fetchingEntryFile"
-        :error="!datasetSelectionStore.serverUrlValid"
-        :error-message="datasetSelectionStore.errorMessage"
-        :dark="globalSettings.darkMode"
-    />
-    <q-select
-        v-if="
-            datasetSelectionStore.serverUrlValid &&
-            datasetSelectionTrrackedStore.serverUrl
-        "
-        label="Experiment"
-        v-model="datasetSelectionTrrackedStore.currentExperimentFilename"
-        :display-value="shortExpName"
-        :options="datasetSelectionStore.experimentFilenameList"
-        :dark="globalSettings.darkMode"
-    />
+    <div style="display: flex; flex-direction: row">
+        <q-select
+            label="Experiment"
+            v-model="datasetSelectionTrrackedStore.currentExperimentFilename"
+            :display-value="shortExpName"
+            :options="datasetSelectionStore.experimentFilenameList"
+            :dark="globalSettings.darkMode"
+            style="flex: 1"
+        />
+        <q-btn
+            flat
+            icon="mdi-refresh"
+            @click="datasetSelectionStore.refreshFileNameList"
+        ></q-btn>
+    </div>
+
     <div
         v-if="
             datasetSelectionStore.currentExperimentMetadata &&

--- a/apps/client/src/components/globalSettings/DatasetSelector.vue
+++ b/apps/client/src/components/globalSettings/DatasetSelector.vue
@@ -4,12 +4,10 @@ import { useQuasar } from 'quasar';
 import { useGlobalSettings } from '@/stores/globalSettings';
 import { useDatasetSelectionTrrackedStore } from '@/stores/datasetSelectionTrrackedStore';
 import { useDatasetSelectionStore } from '@/stores/datasetSelectionStore';
-import { useDataPointSelection } from '@/stores/dataPointSelection';
 
 const globalSettings = useGlobalSettings();
 const datasetSelectionStore = useDatasetSelectionStore();
 const datasetSelectionTrrackedStore = useDatasetSelectionTrrackedStore();
-const dataPointSelection = useDataPointSelection();
 const $q = useQuasar();
 
 watch(
@@ -40,32 +38,17 @@ const shortExpName = computed<string>(() => {
     }
     return shortName;
 });
-
-function openExampleDataset() {
-    datasetSelectionTrrackedStore.serverUrl =
-        'apps.vdl.sci.utah.edu/aardvark-s3';
-
-    datasetSelectionTrrackedStore.currentExperimentFilename = 'Example_1.json';
-    datasetSelectionTrrackedStore.selectedLocationIds['loc_4_well_23'] = true;
-}
 </script>
 
 <template>
-    <q-btn
-        outline
-        rounded
-        class="full-width q-mb-md"
-        @click="openExampleDataset"
-        >Load Example Dataset</q-btn
-    >
-    <div style="display: flex; flex-direction: row">
+    <div class="flex row">
         <q-select
             label="Experiment"
             v-model="datasetSelectionTrrackedStore.currentExperimentFilename"
             :display-value="shortExpName"
             :options="datasetSelectionStore.experimentFilenameList"
             :dark="globalSettings.darkMode"
-            style="flex: 1"
+            class="flex-grow-1"
         />
         <q-btn
             flat

--- a/apps/client/src/stores/configStore.ts
+++ b/apps/client/src/stores/configStore.ts
@@ -6,9 +6,11 @@ export const useConfigStore = defineStore('configStore', () => {
             ? import.meta.env.VITE_ENVIRONMENT
             : 'production';
     let useHttp = import.meta.env.VITE_USE_HTTP?.toLowerCase() === 'true';
+    let envServerUrl = import.meta.env.VITE_SERVER_URL;
 
     return {
         environment,
         useHttp,
+        envServerUrl,
     };
 });

--- a/apps/client/src/stores/datasetSelectionTrrackedStore.ts
+++ b/apps/client/src/stores/datasetSelectionTrrackedStore.ts
@@ -1,6 +1,7 @@
 import { ref, computed } from 'vue';
 import { defineStore } from 'pinia';
 import { useStorage } from '@vueuse/core';
+import { useConfigStore } from '@/stores/configStore';
 
 export interface SelectedLocationIds {
     [index: string]: boolean;
@@ -9,7 +10,8 @@ export interface SelectedLocationIds {
 export const useDatasetSelectionTrrackedStore = defineStore(
     'datasetSelectionTrrackedStore',
     () => {
-        const serverUrl = useStorage<string | null>('serverUrl', null);
+        const configStore = useConfigStore();
+        const serverUrl = ref<string>(configStore.envServerUrl);
         const entryPointFilename = '/aa_index.json';
         const currentExperimentFilename = ref<string | null>(null);
         const selectedLocationIds = ref<SelectedLocationIds>({});

--- a/apps/client/src/stores/globalSettings.ts
+++ b/apps/client/src/stores/globalSettings.ts
@@ -17,7 +17,7 @@ export interface SettingsPage {
 export const useGlobalSettings = defineStore('globalSettings', () => {
     const settingsPages = ref<SettingsPage[]>([
         {
-            name: 'Select Dataset Location',
+            name: 'Select Dataset',
             faKey: 'fa-database',
             id: 1,
             show: true,

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -4,10 +4,12 @@ FROM node:20.11.1-alpine AS build-step
 # Define build arguments for environment variables
 ARG VITE_USE_HTTP
 ARG VITE_ENVIRONMENT
+ARG VITE_SERVER_URL
 
 # Set environment variables during the build process
 ENV VITE_USE_HTTP=$VITE_USE_HTTP
 ENV VITE_ENVIRONMENT=$VITE_ENVIRONMENT
+ENV VITE_SERVER_URL=$VITE_SERVER_URL
 
 
 # Set the working directory.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   # Depends on server. NGINX will throw errors if api endpoints are not setup.
@@ -9,13 +9,14 @@ services:
       args:
         VITE_USE_HTTP: ${VITE_USE_HTTP}
         VITE_ENVIRONMENT: ${VITE_ENVIRONMENT}
+        VITE_SERVER_URL: ${VITE_SERVER_URL}
     ports:
       - "80:80"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf # relative to docker compose
     depends_on:
       - server
-      
+
   # Depends on database. Database must be healthy before starting server
   server:
     build:
@@ -26,12 +27,12 @@ services:
     environment:
       DJANGO_ENV_FILE: "/app/.env"
     depends_on:
-        db:
-          condition: service_healthy
-        redis:
-          condition: service_healthy
-        minio:
-          condition: service_healthy  
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
     volumes:
       - ./.env:/app/.env # relative to docker compose
       - ./server-entrypoint.sh:/app/server-entrypoint.sh # relative to docker compose
@@ -40,14 +41,18 @@ services:
     build:
       context: ../apps/server # relative to docker compose
       dockerfile: ../../docker/Dockerfile.celery # relatvie to build context
-    command: [
-      "celery",
-      "--app", "celery_app",
-      "worker",
-      "--loglevel", "info",
-      "--without-heartbeat",
-      "-c", "4"
-    ]
+    command:
+      [
+        "celery",
+        "--app",
+        "celery_app",
+        "worker",
+        "--loglevel",
+        "info",
+        "--without-heartbeat",
+        "-c",
+        "4",
+      ]
     # Docker Compose does not set the TTY width, which causes Celery errors
     tty: false
     environment:
@@ -55,14 +60,12 @@ services:
     volumes:
       - ./.env:/app/.env # relative to docker compose
     depends_on:
-        db:
-          condition: service_healthy
-        redis:
-          condition: service_healthy
-        minio:
-          condition: service_healthy  
-
-
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
 
   # MySQL service. Has healthcheck which uses mysqladmin to ping before reporting healthy.
   db:
@@ -77,7 +80,17 @@ services:
     ports:
       - "3306:3306"
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${DATABASE_ROOT_PASSWORD}"]
+      test:
+        [
+          "CMD",
+          "mysqladmin",
+          "ping",
+          "-h",
+          "localhost",
+          "-u",
+          "root",
+          "-p${DATABASE_ROOT_PASSWORD}",
+        ]
       timeout: 20s
       retries: 10
     env_file:
@@ -113,6 +126,3 @@ services:
     volumes:
       - ./minio-data:/data
       - ./minio-healthcheck.sh/:/minio-healthcheck.sh
-
-
-    


### PR DESCRIPTION
… caching, added refresh button.

### Does this PR close any open issues?
Closes #49 , #50 

### Give a longer description of what this PR addresses and why it's needed
Disabled caching by changing URL for fetching to use the current time as a query parameter (simple way to always fetch new file). The filename list computed value is now dependent on a "refreshTime" variable. This variable is a string which is appended to the fetch url. Added a method to refresh this time and then a button next to the experiment list. That way, the refresh button gets a new time, the computed experiment list recognized a new time and refetches the list. 

Additionally, the serverURL has been moved to the .env file as "VITE_SERVER_URL". To test out locally, you use "localhost/data". 

### Provide pictures/videos of the behavior before and after these changes (optional)
![Screenshot 2024-08-05 at 12 38 07 PM (2)](https://github.com/user-attachments/assets/1111e996-0991-48ff-9f9c-f1f45cdb6725)

