### PR TITLE
Added validation for experiment name in backend. Validation on field …

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -20,7 +20,7 @@
         "@hms-dbmi/viv": "0.15.1",
         "@luma.gl/core": "^8.5.18",
         "@mdi/font": "^7.1.96",
-        "@quasar/extras": "^1.15.10",
+        "@quasar/extras": "^1.16.12",
         "@trrack/core": "^1.1.0",
         "@trrack/vis-react": "1.4.0",
         "@types/d3-hierarchy": "^3.1.1",

--- a/apps/client/src/components/upload/StepExperimentMetadata.vue
+++ b/apps/client/src/components/upload/StepExperimentMetadata.vue
@@ -1,16 +1,17 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useUploadStore } from '@/stores/uploadStore';
 import { useGlobalSettings } from '@/stores/globalSettings';
 const uploadStore = useUploadStore();
 const globalSettings = useGlobalSettings();
+
+function onInput() {
+    uploadStore.experimentNameValid = true;
+}
 </script>
 
 <template>
-    <div>
-        Select experiment metadata. The experiment name must be unique. We don't
-        currently check this for you. Including today's data in the name is one
-        good way to help ensure uniqueness.
-    </div>
+    <div>Select experiment metadata. The experiment name must be unique.</div>
     <q-input
         class="q-mt-md"
         v-model="uploadStore.experimentName"
@@ -20,6 +21,13 @@ const globalSettings = useGlobalSettings();
         :rules="[(val) => !!val || 'Field is required']"
         label="Experiment Name"
         :dark="globalSettings.darkMode"
+        :error="!uploadStore.experimentNameValid"
+        :error-message="
+            !uploadStore.experimentNameValid
+                ? 'Name is already in use.'
+                : 'Field is required'
+        "
+        @update:model-value="onInput"
     >
     </q-input>
 </template>

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -23,7 +23,7 @@ import TrrackVisWrapper from './components/TrrackVisWrapper.vue';
 import NoDataSplash from './components/NoDataSplash.vue';
 import { router } from './router';
 
-import { Quasar, Loading } from 'quasar';
+import { Quasar, Loading, Notify } from 'quasar';
 // Import icon libraries
 import '@quasar/extras/material-icons/material-icons.css';
 
@@ -65,7 +65,7 @@ createApp(App)
     .use(createPinia())
     .use(vuetify)
     .use(Quasar, {
-        plugins: { Loading }, // import Quasar plugins and add here,
+        plugins: { Loading, Notify }, // import Quasar plugins and add here,
         config: {
             loading: {
                 delay: 0,

--- a/apps/client/src/pages/UploadPage.vue
+++ b/apps/client/src/pages/UploadPage.vue
@@ -45,13 +45,15 @@ function returnHome(): void {
 const $q = useQuasar();
 
 async function handleNextStep(): Promise<void> {
-    if (uploadStore.step === 'finalReview') {
-        uploadStore.uploadAll();
-    } else if (uploadStore.step === 'metadata') {
+    if (uploadStore.step === 'finalReview' || uploadStore.step === 'metadata') {
         const verifyExperimentName = await uploadStore.verifyExperimentName();
         if (verifyExperimentName) {
             uploadStore.experimentNameValid = true;
-            (stepper.value as any).next();
+            if (uploadStore.step === 'metadata') {
+                (stepper.value as any).next();
+            } else {
+                uploadStore.uploadAll();
+            }
         } else {
             $q.notify({
                 color: 'negative',

--- a/apps/client/src/pages/UploadPage.vue
+++ b/apps/client/src/pages/UploadPage.vue
@@ -9,11 +9,13 @@ import type { QStepper } from 'quasar';
 import { useUploadStore } from '@/stores/uploadStore';
 import { useConfigStore } from '@/stores/configStore';
 import { useGlobalSettings } from '@/stores/globalSettings';
+import { useQuasar } from 'quasar';
 
 import { router } from '@/router';
 const uploadStore = useUploadStore();
 const configStore = useConfigStore();
 const globalSettings = useGlobalSettings();
+const stepper = ref(null);
 
 // Function to determine if the create experiment button should be enabled.
 function disableUpload(): boolean {
@@ -25,7 +27,7 @@ function disableUpload(): boolean {
 }
 
 function experimentMetadataDone(): boolean {
-    return uploadStore.validExperimentName();
+    return uploadStore.experimentNameValid;
 }
 
 function fileSelectionDone(): boolean {
@@ -38,6 +40,34 @@ function columnNameMappingDone(): boolean {
 
 function returnHome(): void {
     router.push('/');
+}
+
+const $q = useQuasar();
+
+async function handleNextStep(): Promise<void> {
+    if (uploadStore.step === 'finalReview') {
+        uploadStore.uploadAll();
+    } else if (uploadStore.step === 'metadata') {
+        const verifyExperimentName = await uploadStore.verifyExperimentName();
+        if (verifyExperimentName) {
+            uploadStore.experimentNameValid = true;
+            (stepper.value as any).next();
+        } else {
+            $q.notify({
+                color: 'negative',
+                message: 'Experiment Name already in use.',
+                icon: 'report_problem',
+                position: 'top',
+            });
+            uploadStore.experimentNameValid = false;
+        }
+    } else {
+        (stepper.value as any).next();
+    }
+}
+
+function handlePreviousStep(): void {
+    (stepper.value as any).previous();
 }
 </script>
 <template>
@@ -114,16 +144,12 @@ function returnHome(): void {
                             v-if="uploadStore.step !== 'metadata'"
                             flat
                             color="primary"
-                            @click="($refs.stepper as any).previous()"
+                            @click="handlePreviousStep"
                             label="Back"
                             class="q-ml-sm"
                         />
                         <q-btn
-                            @click="
-                                uploadStore.step === 'finalReview'
-                                    ? uploadStore.uploadAll()
-                                    : ($refs.stepper as any).next()
-                            "
+                            @click="handleNextStep"
                             color="primary"
                             :label="
                                 uploadStore.step === 'finalReview'

--- a/apps/client/src/stores/uploadStore.ts
+++ b/apps/client/src/stores/uploadStore.ts
@@ -5,6 +5,7 @@ import {
     type ProcessResponseData,
     type StatusResponseData,
     type CreateExperimentResponseData,
+    type VerifyExperimentNameResponseData,
 } from '@/util/axios';
 
 import type { ProgressRecord } from '@/components/upload/LoadingProgress.vue';
@@ -86,6 +87,7 @@ const initialState = () => ({
             },
         },
     ]),
+    experimentNameValid: ref<boolean>(true),
 });
 
 export const useUploadStore = defineStore('uploadStore', () => {
@@ -103,6 +105,7 @@ export const useUploadStore = defineStore('uploadStore', () => {
         columnMappings,
         columnNames,
         step,
+        experimentNameValid,
     } = initialState();
 
     function resetState(): void {
@@ -116,11 +119,20 @@ export const useUploadStore = defineStore('uploadStore', () => {
         columnMappings.value = newState.columnMappings.value;
         columnNames.value = newState.columnNames.value;
         step.value = newState.step.value;
+        experimentNameValid.value = newState.experimentNameValid.value;
     }
 
-    function validExperimentName(): boolean {
-        // TODO: this should maybe check if the name is already used?
-        return experimentName.value.length > 0;
+    async function verifyExperimentName(): Promise<boolean> {
+        const verifyExperimentName = await loonAxios.verifyExperimentName(
+            experimentName.value
+        );
+
+        const verifyExperimentNameData: VerifyExperimentNameResponseData =
+            verifyExperimentName.data;
+        if (verifyExperimentNameData.status === 'SUCCESS') {
+            return true;
+        }
+        return false;
     }
 
     const experimentConfig = computed<LocationConfig[] | null>(() => {
@@ -510,7 +522,7 @@ export const useUploadStore = defineStore('uploadStore', () => {
     return {
         experimentCreated,
         experimentName,
-        validExperimentName,
+        verifyExperimentName,
         numberOfLocations,
         locationFileList,
         allFilesPopulated,
@@ -529,5 +541,6 @@ export const useUploadStore = defineStore('uploadStore', () => {
         columnNames,
         resetState,
         step,
+        experimentNameValid,
     };
 });

--- a/apps/client/src/util/axios.ts
+++ b/apps/client/src/util/axios.ts
@@ -27,6 +27,9 @@ interface LoonAxiosInstance extends AxiosInstance {
         experiment_headers: string[] | null,
         experiment_transforms: Record<string, string> | null
     ): AxiosPromise<CreateExperimentResponseData>;
+    verifyExperimentName(
+        experiment_name: string
+    ): AxiosPromise<VerifyExperimentNameResponseData>;
 }
 
 export interface StatusResponseData {
@@ -44,6 +47,10 @@ export interface ProcessResponseData {
 export interface CreateExperimentResponseData {
     status: string;
     message?: string;
+}
+
+export interface VerifyExperimentNameResponseData {
+    status: string;
 }
 
 export function createLoonAxiosInstance(
@@ -118,6 +125,13 @@ export function createLoonAxiosInstance(
         );
     };
 
+    Proto.verifyExperimentName = async function (
+        experiment_name: string
+    ): AxiosPromise<VerifyExperimentNameResponseData> {
+        return this.get(
+            `${this.defaults.baseURL}/verifyExperimentName/${experiment_name}`
+        );
+    };
     axiosInstance.interceptors.response.use(
         (response) => response,
         (error) => {

--- a/apps/client/yarn.lock
+++ b/apps/client/yarn.lock
@@ -839,10 +839,10 @@
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-"@quasar/extras@^1.15.10":
-  version "1.16.6"
-  resolved "https://registry.npmjs.org/@quasar/extras/-/extras-1.16.6.tgz"
-  integrity sha512-yHvp2Z73LuS29fhjE+dSzUvEKGCuTTy+WGIsAYxbnhBVW2rTYlYmFQfGdOPdzNreHZh+G/1D56n0Q6ClZxJHKg==
+"@quasar/extras@^1.16.12":
+  version "1.16.12"
+  resolved "https://registry.yarnpkg.com/@quasar/extras/-/extras-1.16.12.tgz#2dac82eac8bb6b069a677d2817e479261d51f234"
+  integrity sha512-hLlb3Buxo38Xg/2w0BTkz98RBh/VH8apZ2r6Fl8YpPgrVQ0diHyN/BVTvIOk5Kch2y38L2kvwOIddsB2UcCuIg==
 
 "@quasar/vite-plugin@^1.3.0":
   version "1.5.0"

--- a/apps/server/api/processing_callbacks/roi_to_geojson.py
+++ b/apps/server/api/processing_callbacks/roi_to_geojson.py
@@ -26,10 +26,12 @@ def roi_to_geojson(file_contents: bytes, file_name: str) -> Tuple[bytes, str]:
     )
 
     data = feature_to_json(feature)
-    new_file_name = file_name.rstrip('.roi') + '.json'
+    if file_name.endswith('.roi'):
+        file_name = file_name[:-4] + ".json"
+
     data_bytes = data.encode('utf-8')
 
-    return data_bytes, new_file_name
+    return data_bytes, file_name
 
 
 def parse_frame(filename: str) -> int:

--- a/apps/server/api/views.py
+++ b/apps/server/api/views.py
@@ -155,3 +155,19 @@ class FinishExperimentView(APIView):
         default_storage.save(index_file_name, ContentFile(json_index_file_bytes))
 
         return Response({'status': 'SUCCESS'})
+
+
+class VerifyExperimentNameView(APIView):
+    def get(self, request, experiment_name):
+        with default_storage.open('aa_index.json', 'r') as file:
+            content = file.read()
+
+        experiment_list = json.loads(content)['experiments']
+
+        # Removes '.json' from both strings
+        experiment_list_stripped = [element.rstrip('.json') for element in experiment_list]
+
+        if experiment_name.rstrip('.json') in experiment_list_stripped:
+            return Response({'status': 'FAILED'})
+
+        return Response({'status': 'SUCCESS'})

--- a/apps/server/server/urls.py
+++ b/apps/server/server/urls.py
@@ -17,7 +17,7 @@ Including another URLconf
 
 from django.contrib import admin  # type: ignore
 from django.urls import path, include  # type: ignore
-from api.views import FinishExperimentView, ProcessDataView
+from api.views import FinishExperimentView, ProcessDataView, VerifyExperimentNameView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -25,4 +25,8 @@ urlpatterns = [
     path("api/process/<str:task_id>", ProcessDataView.as_view(), name="process-status"),
     path("api/createExperiment/", FinishExperimentView.as_view(), name="finish-experiment"),
     path('api/s3-upload/', include('s3_file_field.urls')),
+    path('api/verifyExperimentName/<str:experiment_name>',
+         VerifyExperimentNameView.as_view(),
+         name="verify-experiment-name"
+         )
 ]


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #47 

### Give a longer description of what this PR addresses and why it's needed
To prevent users from using the same experiment name twice, we've added a URL in the backend which can be fetched to validate the experiment name. This simply pulls in the aa_index.json file and ensures that the name is not already in the list of experiments.

On the front end, the "nextStep" button now triggers this verification when the step is on the 'metadata' page with the current experiment name. If it already exists, we use quasar's built in notification to notify the user. We also trigger the invalid styling on the box (i.e. red border and text, error icon to the right, error message on bottom of input). Upon changing the input, the validation will go away (this does not require an additional function call -- we simply just remove the error when the user changes the value. If the user again inputs a name already in use, it will be re-triggered when they try to continue). The "field is required" messaging still works as expected.

**EDIT 08/12/24:** The ViewExperiment route now also checks the existing directories and the experiment table. This is to avoid issues with aa_index.json file updating last in the process. Additionally, the route is also checked before processing. This is to avoid any race conditions. Specifically, two users uploading an experiment with the same name. In the previous version, a user could start the upload process with an experiment name of "MyExperimentName" even if a process using "MyExperimentName" is already running (since the original check was only checking the aa_index.json file which is updated once all files have finished processing).

### Provide pictures/videos of the behavior before and after these changes (optional)
![Screenshot 2024-08-05 at 4 30 24 PM (2)](https://github.com/user-attachments/assets/a9ab4fe8-f85e-4492-ac79-2965a509b7e7)

