### PR TITLE
CSV Header Fix, Progress Status fixes

### DIFF
--- a/apps/client/src/components/upload/LoadingProgress.vue
+++ b/apps/client/src/components/upload/LoadingProgress.vue
@@ -13,39 +13,10 @@ const props = defineProps({
         required: true,
     },
 });
-const determineProgress = (subProgress: ProgressRecord[]) => {
-    const failed = subProgress.some((element) => element.progress === 'failed');
-    if (failed) {
-        // If any failed, set total to failed
-        return 'failed';
-    } else {
-        const running = subProgress.some(
-            (element) =>
-                element.progress === 'running' ||
-                element.progress === 'dispatched'
-        );
-        if (running) {
-            // If none failed but any are running/queued, set to running
-            return 'running';
-        } else {
-            const succeeded = subProgress.every(
-                (element) => element.progress === 'succeeded'
-            );
-            if (succeeded) {
-                // If none running, none failed, and all have succeeded, set to 3
-                return 'succeeded';
-            }
-        }
-    }
-    // If none running, none failed, and not all succeeded, then it's still starting. Return 0
-    return 'not_started';
-};
+
 const getProgresses = (progressStatus: ProgressRecord[]) => {
     let tempProgressStatus: [ProgressRecord, string][] = progressStatus.map(
         (entry: ProgressRecord) => {
-            if (entry.subProgress) {
-                return [entry, determineProgress(entry.subProgress)];
-            }
             return [entry, entry.progress];
         }
     );

--- a/apps/client/src/components/upload/StepColumnNameMapping.vue
+++ b/apps/client/src/components/upload/StepColumnNameMapping.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onActivated, watch } from 'vue';
+import { ref } from 'vue';
 import { useUploadStore } from '@/stores/uploadStore';
 import { useGlobalSettings } from '@/stores/globalSettings';
 const uploadStore = useUploadStore();
@@ -46,10 +46,6 @@ const specialVariables = ref<SpecialVariable[]>([
     },
 ]);
 
-// onActivated(() => {
-//     console.log('hook called');
-//     uploadStore.populateDefaultColumnMappings();
-// });
 </script>
 
 <template>

--- a/apps/client/src/components/upload/StepColumnNameMapping.vue
+++ b/apps/client/src/components/upload/StepColumnNameMapping.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onActivated } from 'vue';
+import { ref, onActivated, watch } from 'vue';
 import { useUploadStore } from '@/stores/uploadStore';
 import { useGlobalSettings } from '@/stores/globalSettings';
 const uploadStore = useUploadStore();
@@ -46,10 +46,10 @@ const specialVariables = ref<SpecialVariable[]>([
     },
 ]);
 
-onActivated(() => {
-    console.log('hook called');
-    uploadStore.populateDefaultColumnMappings();
-});
+// onActivated(() => {
+//     console.log('hook called');
+//     uploadStore.populateDefaultColumnMappings();
+// });
 </script>
 
 <template>

--- a/apps/client/src/components/upload/StepFileSelection.vue
+++ b/apps/client/src/components/upload/StepFileSelection.vue
@@ -30,6 +30,7 @@ const globalSettings = useGlobalSettings();
             v-model="locationFile.table.file"
             label="Table (csv)"
             :dark="globalSettings.darkMode"
+            @update:model-value="uploadStore.populateDefaultColumnMappings"
         />
 
         <q-file

--- a/apps/client/src/components/upload/StepUploadStatus.vue
+++ b/apps/client/src/components/upload/StepUploadStatus.vue
@@ -41,12 +41,26 @@ function addNewExperiment(): void {
                 align-items: center;
             "
         >
-            <template v-if="uploadStore.overallProgress.status !== 2">
+            <template
+                v-if="
+                    uploadStore.overallProgress.status !== 2 &&
+                    uploadStore.overallProgress.status !== -1
+                "
+            >
                 <q-banner inline-actions class="text-white bg-blue">
                     Your data is currently being processed. Please do not exit
                     this page.
                     <template v-slot:avatar>
                         <q-icon name="mdi-alert" color="white" />
+                    </template>
+                </q-banner>
+            </template>
+            <template v-else-if="uploadStore.overallProgress.status === -1">
+                <q-banner inline-actions class="text-white bg-red">
+                    There was an error in one or more processing steps. Your
+                    experiment will need to be re-uploaded.
+                    <template v-slot:avatar>
+                        <q-icon name="mdi-alert-circle-outline" color="white" />
                     </template>
                 </q-banner>
             </template>

--- a/apps/client/src/stores/uploadStore.ts
+++ b/apps/client/src/stores/uploadStore.ts
@@ -437,10 +437,6 @@ export const useUploadStore = defineStore('uploadStore', () => {
     ];
 
     async function populateDefaultColumnMappings() {
-        if (columnMappings.value) {
-            // if it's already populated don't set the defaults
-            return;
-        }
         if (locationFileList.value.length == 0) {
             // if there are no files are selectted don't populate
             return;

--- a/apps/client/src/stores/uploadStore.ts
+++ b/apps/client/src/stores/uploadStore.ts
@@ -275,7 +275,10 @@ export const useUploadStore = defineStore('uploadStore', () => {
 
                     const processResponseData: ProcessResponseData =
                         processResponse.data;
-                    if (processResponseData.task_id) {
+                    if (
+                        processResponseData.task_id &&
+                        fileToUpload.checkForUpdates
+                    ) {
                         checkForUpdates(
                             processResponseData.task_id,
                             fileToUpload

--- a/apps/client/src/stores/uploadStore.ts
+++ b/apps/client/src/stores/uploadStore.ts
@@ -315,6 +315,7 @@ export const useUploadStore = defineStore('uploadStore', () => {
                     if (responseData.data) {
                         uploadingFile.processedData = responseData.data;
                     }
+                    // This only triggers when everything is done since experimentConfig is only computed once all has finished.
                     if (experimentConfig && experimentHeaders) {
                         const submitExperimentResponse: CreateExperimentResponseData =
                             await onSubmitExperiment();
@@ -327,12 +328,14 @@ export const useUploadStore = defineStore('uploadStore', () => {
                                 'There was an error submitting this experiment.';
                         }
                     }
+                    uploadingFile.processing = 'succeeded';
                 } else if (
                     responseData.status === 'FAILED' ||
                     responseData.status === 'ERROR'
                 ) {
                     // show error/failure message
                     updatesAvailable = true;
+                    uploadingFile.processing = 'failed';
                 } else if (responseData.status === 'RUNNING') {
                     // show running symbol like it normally does
                     uploadingFile.processing = 'running';
@@ -342,7 +345,6 @@ export const useUploadStore = defineStore('uploadStore', () => {
                     await new Promise((resolve) => setTimeout(resolve, 5000));
                 }
             }
-            uploadingFile.processing = 'succeeded';
         } catch (error) {
             console.error('Error checking for updates:', error);
             uploadingFile.processing = 'failed';

--- a/apps/client/src/stores/uploadStore.ts
+++ b/apps/client/src/stores/uploadStore.ts
@@ -1,4 +1,4 @@
-import { ref, computed, watch, nextTick } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { defineStore } from 'pinia';
 import {
     createLoonAxiosInstance,

--- a/apps/client/src/stores/uploadStore.ts
+++ b/apps/client/src/stores/uploadStore.ts
@@ -134,7 +134,10 @@ export const useUploadStore = defineStore('uploadStore', () => {
                 locationFiles.segmentations.processedData &&
                 locationFiles.table.processedData
             ) {
-                const imageDataFilename = `${locationFiles.images.processedData.base_file_location}${locationFiles.images.processedData.companion_ome}`;
+                const imageDataFilename = `${locationFiles.images.processedData.base_file_location.replace(
+                    /\/$/,
+                    ''
+                )}/${locationFiles.images.processedData.companion_ome}`;
                 const segmentationsFolder =
                     `${locationFiles.segmentations.processedData.base_file_location}`.replace(
                         /\/$/,

--- a/apps/server/api/tasks.py
+++ b/apps/server/api/tasks.py
@@ -216,8 +216,8 @@ class LiveCyteSegmentationsTask(Task):
     def execute(self):
         logger.info(f"Executing task: {self.record_id}")
         base_file_location = f"{self.experiment_name}/" \
-                f"location_{self.location}/" \
-                "segmentations/cells"
+                             f"location_{self.location}/" \
+                             "segmentations/cells"
         data = self.process_zip_file(base_file_location=base_file_location, callback=roi_to_geojson)
         return data
 
@@ -230,8 +230,8 @@ class LiveCyteCellImagesTask(Task):
     def execute(self):
         logger.info(f"Executing task: {self.record_id}")
         base_file_location = f"{self.experiment_name}/" \
-        f"location_{self.location}/" \
-        "images"
+                             f"location_{self.location}/" \
+                             "images"
         data = self.process_zip_file(base_file_location=base_file_location, callback=None)
         return data
 
@@ -243,10 +243,11 @@ class LiveCyteCellImagesTask(Task):
 class LiveCyteMetadataTask(Task):
     def execute(self):
         logger.info(f"Executing task: {self.record_id}")
-        
+
         base_file_location = f"{self.experiment_name}/" \
-        f"location_{self.location}"
-        data = self.process_csv_file(base_file_location=base_file_location, skip_rows=1, callback=None)
+            f"location_{self.location}"
+        data = self.process_csv_file(base_file_location=base_file_location, skip_rows=1,
+                                     callback=None)
         return data
 
     def cleanup(self):


### PR DESCRIPTION
### Does this PR close any open issues?
Closes #48, #54

### Give a longer description of what this PR addresses and why it's needed
- Header choices are now refreshed whenever the table files change rather than when the column mapping page is activated (using onActivated)
- A new progress has been added: Create Experiment. This happens after the processing
- SubmitExperiment is now called via a watch variable in the upload store rather than inside checkForUpdates
- "DetermineProgress" function which determines the overall progress of a step is now in a computed variable.
- Refactored some of the loading progress code. Now, it is a bit more clear what happens: the raw list of porgresses is initialized (with the values that are specific to what we're doing), then a generic computed variable is outputted which changes the status of a progressRecord depdendent on its subProgresses. Finally, another watch is added to check if all steps have completed, some are still running, or any have failed. This then changes the messaging on the right. 

### Provide pictures/videos of the behavior before and after these changes (optional)
![Screenshot 2024-08-07 at 4 37 54 PM (2)](https://github.com/user-attachments/assets/9bbccf90-c755-4916-a544-bb059c3d3470)
