### PR TITLE
1.24

### DIFF
--- a/apps/client/src/stores/misc/configStore.ts
+++ b/apps/client/src/stores/misc/configStore.ts
@@ -56,6 +56,13 @@ export const useConfigStore = defineStore('configStore', () => {
     function getDuckDbFileUrl(path: string): string {
         // Trims any leading slashes from path
         const trimmedPath = path.replace(/^\/+/, '');
+
+        // In local Docker environment, DuckDB container cannot access 'localhost'
+        // It must use the docker service name 'client'
+        if (environment === 'local') {
+            return `http://client/data/${trimmedPath}`;
+        }
+
         return `${serverUrl}/${trimmedPath}`;
     }
 


### PR DESCRIPTION
**Before:** Error with loading parquet file.

**Fix:** local deployments (like our current loonsw.sci.utah.edu) ensure that we connect to client container.