### PR TITLE
Add ability to name imaging locations

### DIFF
--- a/apps/client/src/components/globalSettings/DatasetSelector.vue
+++ b/apps/client/src/components/globalSettings/DatasetSelector.vue
@@ -36,6 +36,9 @@ function onClickLocation(location: any) {
 }
 
 const shortExpName = computed<string>(() => {
+    if (datasetSelectionStore.currentExperimentMetadata?.name) {
+        return datasetSelectionStore.currentExperimentMetadata.name;
+    }
     let shortName = datasetSelectionTrrackedStore.currentExperimentFilename;
     if (shortName === null) return '';
     shortName = shortName.split('.')[0];

--- a/apps/client/src/components/globalSettings/DatasetSelector.vue
+++ b/apps/client/src/components/globalSettings/DatasetSelector.vue
@@ -99,7 +99,9 @@ function onSelectExperiment() {
                     }
                 "
                 :dark="globalSettings.darkMode"
-                ><q-item-section>{{ location.id }}</q-item-section></q-item
+                ><q-item-section>{{
+                    location.name ?? location.id
+                }}</q-item-section></q-item
             >
         </q-list>
     </div>

--- a/apps/client/src/stores/dataStores/datasetSelectionUntrrackedStore.ts
+++ b/apps/client/src/stores/dataStores/datasetSelectionUntrrackedStore.ts
@@ -44,7 +44,7 @@ export interface LocationMetadata {
     imageDataFilename?: string;
     segmentationsFolder?: string;
     tags?: Tags;
-    // name?: string; // user friendly name
+    name?: string; // user friendly name
     // condition?: string; // experimental condition // TODO: - does this need to be an array
     // plate?: string;
     // well?: string;
@@ -284,7 +284,7 @@ export const useDatasetSelectionStore = defineStore(
                     .locationMetadataList) {
                     if (
                         datasetSelectionTrrackedStore.selectedLocationIds[
-                            location.id
+                        location.id
                         ]
                     ) {
                         return location;


### PR DESCRIPTION
### Does this PR close any open issues?

### Give a longer description of what this PR addresses and why it's needed
- Adds `name` param to json to allow for naming imaging locations
- Ensures that the experiment name specified in the json (Such as Clean_Quil_Trackmate) appears in Loon under "Experiment"
- Needed for issue #197

<img width="281" height="288" alt="Screenshot 2026-02-03 at 11 38 35 AM" src="https://github.com/user-attachments/assets/066f417e-d102-4478-b7e2-86509183fb2e" />
